### PR TITLE
Added basic WebSocket Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # Project specific
 web/static/css/output.css
 web/views/**/*.go
+api/docs/*

--- a/api/api.go
+++ b/api/api.go
@@ -3,21 +3,19 @@ package api
 import (
 	"github.com/gin-gonic/gin"
 
-	docs "github.com/6missedcalls/cobra-gin-starter/api/docs"
 	routes "github.com/6missedcalls/cobra-gin-starter/api/routes"
-	swaggerfiles "github.com/swaggo/files"
-	ginSwagger "github.com/swaggo/gin-swagger"
+	ws "github.com/6missedcalls/cobra-gin-starter/api/websockets"
 )
 
+// @BasePath /api/v1
 func SetupRouter() *gin.Engine {
 	router := gin.Default()
 
 	const bp = "/api/v1"
 	v1 := router.Group(bp)
-	docs.SwaggerInfo.BasePath = bp
+	routes.RegisterSwaggerRoutes(v1)
 	routes.RegisterHealthRoutes(v1)
-
-	v1.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
+	ws.HelloWebsocketHandler(v1)
 
 	return router
 }

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -37,6 +37,29 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/ws": {
+            "get": {
+                "description": "A simple WebSocket endpoint that sends a greeting message.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "example"
+                ],
+                "summary": "Basic WebSocket Implementation",
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     }
 }`

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -26,6 +26,29 @@
                     }
                 }
             }
+        },
+        "/ws": {
+            "get": {
+                "description": "A simple WebSocket endpoint that sends a greeting message.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "example"
+                ],
+                "summary": "Basic WebSocket Implementation",
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -16,4 +16,19 @@ paths:
       summary: ping example
       tags:
       - example
+  /ws:
+    get:
+      consumes:
+      - application/json
+      description: A simple WebSocket endpoint that sends a greeting message.
+      produces:
+      - application/json
+      responses:
+        "101":
+          description: Switching Protocols
+          schema:
+            type: string
+      summary: Basic WebSocket Implementation
+      tags:
+      - example
 swagger: "2.0"

--- a/api/routes/health.go
+++ b/api/routes/health.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 )
 
-// @BasePath /api/v1
-
 // PingExample godoc
 // @Summary ping example
 // @Schemes

--- a/api/routes/swagger.go
+++ b/api/routes/swagger.go
@@ -1,0 +1,14 @@
+package routes
+
+import (
+	docs "github.com/6missedcalls/cobra-gin-starter/api/docs"
+	swaggerfiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterSwaggerRoutes(rg *gin.RouterGroup) {
+	docs.SwaggerInfo.BasePath = "/api/v1"
+	rg.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
+}

--- a/api/websockets/hello.go
+++ b/api/websockets/hello.go
@@ -1,0 +1,49 @@
+package websockets
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize: 1024,
+	WriteBufferSize: 1024,
+}
+
+// HelloWebsocketHandler godoc
+// @Summary Basic WebSocket Implementation
+// @Schemes
+// @Description A simple WebSocket endpoint that sends a greeting message.
+// @Tags example
+// @Accept json
+// @Produce json
+// @Success 101 {string} Hello, WebSocket!
+// @Router /ws [get]
+func HelloWebsocketHandler(r *gin.RouterGroup) {
+	r.GET("/ws", func(c *gin.Context) {
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			c.String(http.StatusInternalServerError, "Failed to upgrade to websocket: %v", err)
+			return
+		}
+		defer func() {
+			if cerr := conn.Close(); cerr != nil {
+				log.Printf("Error closing websocket connection: %v", cerr)
+			}
+		}()
+
+		for {
+			mType, data, err := conn.ReadMessage()
+			if err != nil {
+				break
+			}
+			message := "Hello, WebSocket!, you said: " + string(data)
+			if err := conn.WriteMessage(mType, []byte(message)); err != nil {
+				break
+			}
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/go-playground/validator/v10 v10.27.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=


### PR DESCRIPTION
## Summary
This PR adds a minimal, self-contained WebSocket example to the starter. The goal is to provide an optional reference implementation without enforcing any opinionated architecture or messaging patterns.

### What’s Included
- Basic WebSocket handler using gorilla/websocket
- Route registration under the existing Gin router group
- Simple greeting + echo loop for demonstration
- Safe conn.Close() handling and improved error handling patterns
- Documentation comments + example usage for new users

### Notes
- This does not introduce any architectural decisions (hubs, brokers, rooms, etc.).
- Future optional features (e.g. auth) may be added separately since auth tends to be project-specific.
- The WebSocket example is isolated so it can be easily deleted or expanded.
- This includes a partial resolution to issue #1.